### PR TITLE
Maintenance mode stacking support

### DIFF
--- a/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/HelixAdmin.java
@@ -423,6 +423,16 @@ public interface HelixAdmin {
       Map<String, String> customFields);
 
   /**
+   * Enable maintenance mode via automation systems (like HelixACM). To be called by automation services.
+   * @param clusterName
+   * @param enabled
+   * @param reason
+   * @param customFields user-specified KV mappings to be stored in the ZNode
+   */
+  void automationEnableMaintenanceMode(String clusterName, boolean enabled, String reason,
+      Map<String, String> customFields);
+
+  /**
    * Check specific cluster is in maintenance mode or not
    * @param clusterName the cluster name
    * @return true if in maintenance mode, false otherwise

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1235,14 +1235,10 @@ public class ZKHelixAdmin implements HelixAdmin {
             // If this was the last reason, remove the maintenance ZNode entirely
             accessor.removeProperty(keyBuilder.maintenance());
           }
-        } else {
-          // If old client, just remove the maintenance node entirely
-          accessor.removeProperty(keyBuilder.maintenance());
         }
       }
     } else {
       // Enter maintenance mode
-
       if (maintenanceSignal == null) {
         // Create a new maintenance signal if it doesn't exist
         maintenanceSignal = new MaintenanceSignal(MAINTENANCE_ZNODE_ID);

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -955,7 +955,6 @@ public class ZKHelixAdmin implements HelixAdmin {
       return false;
     }
 
-    // Check if there are any maintenance reasons active
     return signal.hasMaintenanceReasons();
   }
 

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1241,8 +1241,7 @@ public class ZKHelixAdmin implements HelixAdmin {
         if (removed) {
           // If there are still reasons for maintenance mode, update the ZNode
 
-          if (maintenanceSignal.getRecord().getListField("reasons") != null
-              && !maintenanceSignal.getRecord().getListField("reasons").isEmpty()) {
+          if (maintenanceSignal.hasMaintenanceReasons()) {
             if (!accessor.setProperty(keyBuilder.maintenance(), maintenanceSignal)) {
               throw new HelixException("Failed to update maintenance signal!");
             }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1227,7 +1227,8 @@ public class ZKHelixAdmin implements HelixAdmin {
 
         if (removed) {
           // If there are still reasons for maintenance mode, update the ZNode
-          if (maintenanceSignal.hasMaintenanceReasons()) {
+          if (maintenanceSignal.getRecord().getListField("reasons") != null
+              && !maintenanceSignal.getRecord().getListField("reasons").isEmpty()) {
             if (!accessor.setProperty(keyBuilder.maintenance(), maintenanceSignal)) {
               throw new HelixException("Failed to update maintenance signal!");
             }

--- a/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
+++ b/helix-core/src/main/java/org/apache/helix/manager/zk/ZKHelixAdmin.java
@@ -1263,6 +1263,7 @@ public class ZKHelixAdmin implements HelixAdmin {
           maintenanceSignal.setAutoTriggerReason(internalReason);
           break;
         case USER:
+        case AUTOMATION:
         case UNKNOWN:
           // manuallyEnable
           if (customFields != null && !customFields.isEmpty()) {

--- a/helix-core/src/main/java/org/apache/helix/model/ControllerHistory.java
+++ b/helix-core/src/main/java/org/apache/helix/model/ControllerHistory.java
@@ -56,8 +56,8 @@ public class ControllerHistory extends HelixProperty {
     MAINTENANCE_HISTORY,
     OPERATION_TYPE,
     DATE,
-    REASON
-
+    REASON,
+    IN_MAINTENANCE_AFTER_OPERATION
   }
 
   private enum ManagementModeConfigKey {
@@ -180,10 +180,11 @@ public class ControllerHistory extends HelixProperty {
    * @param internalReason
    * @param customFields
    * @param triggeringEntity
+   * @param inMaintenanceAfterOperation whether the cluster is still in maintenance mode after this operation
    */
   public ZNRecord updateMaintenanceHistory(boolean enabled, String reason, long currentTime,
       MaintenanceSignal.AutoTriggerReason internalReason, Map<String, String> customFields,
-      MaintenanceSignal.TriggeringEntity triggeringEntity) throws IOException {
+      MaintenanceSignal.TriggeringEntity triggeringEntity, boolean inMaintenanceAfterOperation) throws IOException {
     DateFormat df = new SimpleDateFormat("yyyy-MM-dd-HH:" + "mm:ss");
     df.setTimeZone(TimeZone.getTimeZone("UTC"));
     String dateTime = df.format(new Date(currentTime));
@@ -198,6 +199,8 @@ public class ControllerHistory extends HelixProperty {
         String.valueOf(currentTime));
     maintenanceEntry.put(MaintenanceSignal.MaintenanceSignalProperty.TRIGGERED_BY.name(),
         triggeringEntity.name());
+    maintenanceEntry.put(MaintenanceConfigKey.IN_MAINTENANCE_AFTER_OPERATION.name(),
+        String.valueOf(inMaintenanceAfterOperation));
     if (triggeringEntity == MaintenanceSignal.TriggeringEntity.CONTROLLER) {
       // If auto-triggered
       maintenanceEntry.put(MaintenanceSignal.MaintenanceSignalProperty.AUTO_TRIGGER_REASON.name(),

--- a/helix-core/src/main/java/org/apache/helix/model/MaintenanceSignal.java
+++ b/helix-core/src/main/java/org/apache/helix/model/MaintenanceSignal.java
@@ -169,11 +169,6 @@ public class MaintenanceSignal extends PauseSignal {
 
     updateReasonsListField(reasons);
     LOG.debug("After addition: Reasons list contains {} entries", reasons.size());
-
-    // Update all the simpleFields for backward compatibility
-    setReason(reason);
-    setTimestamp(timestamp);
-    setTriggeringEntity(triggeringEntity);
   }
 
   /**

--- a/helix-core/src/main/java/org/apache/helix/model/MaintenanceSignal.java
+++ b/helix-core/src/main/java/org/apache/helix/model/MaintenanceSignal.java
@@ -19,12 +19,23 @@ package org.apache.helix.model;
  * under the License.
  */
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Iterator;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import java.io.IOException;
 
 /**
  * A ZNode that signals that the cluster is in maintenance mode.
  */
 public class MaintenanceSignal extends PauseSignal {
+  private static final Logger LOG = LoggerFactory.getLogger(MaintenanceSignal.class);
 
   /**
    * Pre-defined fields set by Helix Controller only.
@@ -40,6 +51,7 @@ public class MaintenanceSignal extends PauseSignal {
    */
   public enum TriggeringEntity {
     CONTROLLER,
+    AUTOMATION, // triggered by automation systems (like HelixACM)
     USER, // manually triggered by user
     UNKNOWN
   }
@@ -56,6 +68,11 @@ public class MaintenanceSignal extends PauseSignal {
     MAX_PARTITION_PER_INSTANCE_EXCEEDED,
     NOT_APPLICABLE // Not triggered automatically or automatically exiting maintenance mode
   }
+
+  /**
+   * Constant for the name of the reasons list field
+   */
+  private static final String REASONS_LIST_FIELD = "reasons";
 
   public MaintenanceSignal(String id) {
     super(id);
@@ -111,5 +128,353 @@ public class MaintenanceSignal extends PauseSignal {
    */
   public long getTimestamp() {
     return _record.getLongField(MaintenanceSignalProperty.TIMESTAMP.name(), -1);
+  }
+
+  /**
+   * Add a new maintenance reason (or update an existing one if the triggering entity already has a reason).
+   *
+   * @param reason The reason for maintenance
+   * @param timestamp The timestamp when maintenance was triggered
+   * @param triggeringEntity The entity that triggered maintenance
+   */
+  public void addMaintenanceReason(String reason, long timestamp, TriggeringEntity triggeringEntity) {
+    LOG.info("Adding maintenance reason for entity: {}, reason: {}, timestamp: {}",
+        triggeringEntity, reason, timestamp);
+
+    // The triggering entity is our unique key - we will overwrite any existing entry with this entity
+    String triggerEntityStr = triggeringEntity.name();
+
+    // Get the current list of reasons
+    List<Map<String, String>> reasons = getMaintenanceReasons();
+    LOG.debug("Before addition: Reasons list contains {} entries", reasons.size());
+
+    // Check if we already have a reason for this entity
+    boolean found = false;
+    for (Map<String, String> entry : reasons) {
+      if (triggerEntityStr.equals(entry.get(MaintenanceSignalProperty.TRIGGERED_BY.name()))) {
+        // Update the existing entry
+        entry.put(PauseSignalProperty.REASON.name(), reason);
+        entry.put(MaintenanceSignalProperty.TIMESTAMP.name(), Long.toString(timestamp));
+        found = true;
+        LOG.debug("Updated existing entry for entity: {}", triggeringEntity);
+        break;
+      }
+    }
+
+    // If we didn't find an entry, add a new one
+    if (!found) {
+      Map<String, String> newEntry = new HashMap<>();
+      newEntry.put(PauseSignalProperty.REASON.name(), reason);
+      newEntry.put(MaintenanceSignalProperty.TIMESTAMP.name(), Long.toString(timestamp));
+      newEntry.put(MaintenanceSignalProperty.TRIGGERED_BY.name(), triggerEntityStr);
+      reasons.add(newEntry);
+      LOG.debug("Added new entry for entity: {}", triggeringEntity);
+    }
+
+    // Update the ZNRecord with our updated list
+    updateReasonsListField(reasons);
+    LOG.debug("After addition: Reasons list contains {} entries", reasons.size());
+
+    // Update all the simpleFields for backward compatibility
+    setReason(reason);
+    _record.setSimpleField("reason", reason); // Also update lowercase "reason" for complete compatibility
+    setTimestamp(timestamp);
+    setTriggeringEntity(triggeringEntity);
+  }
+
+  /**
+   * Helper method to update the ZNRecord with the current reasons list.
+   * Each reason is stored as a single JSON string in the list.
+   *
+   * @param reasons The list of reason maps to store
+   */
+  private void updateReasonsListField(List<Map<String, String>> reasons) {
+    List<String> reasonsList = new ArrayList<>();
+
+    for (Map<String, String> entry : reasons) {
+      String jsonString = convertMapToJsonString(entry);
+      if (!jsonString.isEmpty()) {
+        reasonsList.add(jsonString);
+      }
+    }
+
+    _record.setListField(REASONS_LIST_FIELD, reasonsList);
+  }
+
+  /**
+   * Convert a map to a JSON-style string
+   */
+  private String convertMapToJsonString(Map<String, String> map) {
+    try {
+      return new ObjectMapper().writeValueAsString(map);
+    } catch (IOException e) {
+      LOG.warn("Failed to convert map to JSON string: {}", e.getMessage());
+      // Fallback to a simple representation if JSON serialization fails
+      return "";
+    }
+  }
+
+  /**
+   * Get all maintenance reasons currently active.
+   *
+   * @return List of maintenance reasons as maps
+   */
+  public List<Map<String, String>> getMaintenanceReasons() {
+    List<Map<String, String>> reasons = new ArrayList<>();
+    List<String> reasonsList = _record.getListField(REASONS_LIST_FIELD);
+
+    if (reasonsList == null || reasonsList.isEmpty()) {
+      // If the list doesn't exist but simple fields do, add the simple fields as the first reason
+      String simpleReason = getReason();
+      if (simpleReason != null) {
+        Map<String, String> entry = new HashMap<>();
+        entry.put(PauseSignalProperty.REASON.name(), simpleReason);
+        entry.put(MaintenanceSignalProperty.TIMESTAMP.name(), String.valueOf(getTimestamp()));
+        entry.put(MaintenanceSignalProperty.TRIGGERED_BY.name(), getTriggeringEntity().name());
+
+        reasons.add(entry);
+      }
+    } else {
+      // Parse each entry as a JSON-formatted string
+      for (String entryStr : reasonsList) {
+        Map<String, String> entry = parseJsonStyleEntry(entryStr);
+        if (!entry.isEmpty()) {
+          reasons.add(entry);
+        }
+      }
+    }
+
+    return reasons;
+  }
+
+  /**
+   * Parse an entry string in JSON format into a map
+   */
+  private Map<String, String> parseJsonStyleEntry(String entryStr) {
+    Map<String, String> map = new HashMap<>();
+    try {
+        return new ObjectMapper().readValue(entryStr,
+            TypeFactory.defaultInstance().constructMapType(HashMap.class, String.class, String.class));
+      } catch (IOException e) {
+        LOG.warn("Failed to parse JSON entry: {}, error: {}", entryStr, e.getMessage());
+      }
+    return map;
+  }
+
+  /**
+   * Remove a maintenance reason by triggering entity.
+   *
+   * @param triggeringEntity The entity whose reason should be removed
+   * @return true if a reason was removed, false otherwise
+   */
+  public boolean removeMaintenanceReason(TriggeringEntity triggeringEntity) {
+    LOG.info("Removing maintenance reason for entity: {}", triggeringEntity);
+
+    // Get the current list of reasons
+    List<Map<String, String>> reasons = getMaintenanceReasons();
+    int originalSize = reasons.size();
+
+    LOG.debug("Before removal: Reasons list contains {} entries", reasons.size());
+
+    // Create a new list to avoid modifying the original during iteration
+    List<Map<String, String>> updatedReasons = new ArrayList<>();
+    String targetEntity = triggeringEntity.name();
+
+    // Only keep reasons that don't match the triggering entity
+    for (Map<String, String> entry : reasons) {
+      String entryEntity = entry.get(MaintenanceSignalProperty.TRIGGERED_BY.name());
+      if (!targetEntity.equals(entryEntity)) {
+        updatedReasons.add(entry);
+      } else {
+        LOG.debug("Removing entry with reason: {} for entity: {}",
+            entry.get(PauseSignalProperty.REASON.name()), entryEntity);
+      }
+    }
+
+    boolean removed = updatedReasons.size() < originalSize;
+    LOG.debug("After removal: Reasons list contains {} entries", updatedReasons.size());
+
+    if (removed) {
+      // Update the ZNRecord with the new reasons
+      updateReasonsListField(updatedReasons);
+
+      // Update the simpleFields with the most recent reason (for backward compatibility)
+      if (!updatedReasons.isEmpty()) {
+        // Sort by timestamp in descending order to get the most recent
+        updatedReasons.sort((r1, r2) -> {
+          long t1 = Long.parseLong(r1.get(MaintenanceSignalProperty.TIMESTAMP.name()));
+          long t2 = Long.parseLong(r2.get(MaintenanceSignalProperty.TIMESTAMP.name()));
+          return Long.compare(t2, t1);
+        });
+
+        // Update simple fields with the most recent
+        Map<String, String> mostRecent = updatedReasons.get(0);
+        String newReason = mostRecent.get(PauseSignalProperty.REASON.name());
+        long newTimestamp = Long.parseLong(mostRecent.get(MaintenanceSignalProperty.TIMESTAMP.name()));
+        TriggeringEntity newEntity = TriggeringEntity.valueOf(
+            mostRecent.get(MaintenanceSignalProperty.TRIGGERED_BY.name()));
+
+        LOG.info("Updated to most recent reason: {}, entity: {}, timestamp: {}",
+            newReason, newEntity, newTimestamp);
+
+        setReason(newReason);
+        _record.setSimpleField("reason", newReason); // Also update lowercase "reason" for complete compatibility
+        setTimestamp(newTimestamp);
+        setTriggeringEntity(newEntity);
+      } else {
+        // If no reasons left, clear all fields
+        LOG.info("No maintenance reasons remaining, clearing all fields");
+        setReason(null);
+        _record.setSimpleField("reason", null);
+        setTimestamp(System.currentTimeMillis());
+        setTriggeringEntity(TriggeringEntity.UNKNOWN);
+      }
+    } else {
+      LOG.info("No matching maintenance reason found for entity: {}", triggeringEntity);
+    }
+
+    return removed;
+  }
+
+  /**
+   * Check if there are any active maintenance reasons.
+   *
+   * @return true if there are any reasons for maintenance, false otherwise
+   */
+  public boolean hasMaintenanceReasons() {
+    return !getMaintenanceReasons().isEmpty();
+  }
+
+  /**
+   * Update the maintenance reason list to ensure all data is consistent.
+   * This is used when handling potential inconsistencies between simpleFields and
+   * the reasons list, which can happen with old clients.
+   *
+   * @return true if list was updated, false if no change was needed
+   */
+  public boolean reconcileMaintenanceData() {
+    // Get the reason from simple fields
+    String simpleReason = getReason();
+
+    // If simpleFields are null or empty, nothing to reconcile
+    if (simpleReason == null) {
+      return false;
+    }
+    long simpleTimestamp = getTimestamp();
+    TriggeringEntity simpleTriggeringEntity = getTriggeringEntity();
+
+    // Look at the raw reasons list - don't use getMaintenanceReasons() as it already
+    // synthesizes entries from simple fields which would create a circular dependency
+    List<String> rawReasonsList = _record.getListField(REASONS_LIST_FIELD);
+    List<Map<String, String>> parsedReasons = new ArrayList<>();
+
+    // If there's no list field at all, we'll need to create one
+    boolean needsUpdate = (rawReasonsList == null);
+
+    if (rawReasonsList != null) {
+      // Parse each entry to check if our simple fields already have a corresponding entry
+      for (String entryStr : rawReasonsList) {
+        Map<String, String> entry = parseJsonStyleEntry(entryStr);
+        if (!entry.isEmpty()) {
+          parsedReasons.add(entry);
+        }
+      }
+    } else {
+      // Create a new list
+      rawReasonsList = new ArrayList<>();
+    }
+
+    // Check if the triggering entity from simple fields already has an entry
+    boolean alreadyPresent = false;
+    for (Map<String, String> entry : parsedReasons) {
+      if (simpleTriggeringEntity.name().equals(entry.get(MaintenanceSignalProperty.TRIGGERED_BY.name()))) {
+        // Check if timestamps are different
+        long entryTimestamp = Long.parseLong(entry.get(MaintenanceSignalProperty.TIMESTAMP.name()));
+        if (simpleTimestamp > entryTimestamp) {
+          // If simple field timestamp is newer, update the entry
+          entry.put(PauseSignalProperty.REASON.name(), simpleReason);
+          entry.put(MaintenanceSignalProperty.TIMESTAMP.name(), Long.toString(simpleTimestamp));
+          needsUpdate = true;
+        }
+        alreadyPresent = true;
+        break;
+      }
+    }
+
+    // If simple fields exist but not in the reasons list, add them
+    if (!alreadyPresent) {
+      Map<String, String> newEntry = new HashMap<>();
+      newEntry.put(PauseSignalProperty.REASON.name(), simpleReason);
+      newEntry.put(MaintenanceSignalProperty.TIMESTAMP.name(), Long.toString(simpleTimestamp));
+      newEntry.put(MaintenanceSignalProperty.TRIGGERED_BY.name(), simpleTriggeringEntity.name());
+
+      parsedReasons.add(newEntry);
+      needsUpdate = true;
+
+      LOG.debug("Added missing reason for {} to reasons list during reconciliation",
+          simpleTriggeringEntity);
+    }
+
+    if (needsUpdate) {
+      // Update the ZNRecord with the new reasons
+      updateReasonsListField(parsedReasons);
+      LOG.debug("Updated reasons list after reconciliation, now contains {} entries",
+          parsedReasons.size());
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks if there is a maintenance reason from a specific triggering entity.
+   *
+   * @param triggeringEntity The entity to check
+   * @return true if there is a maintenance reason from this entity
+   */
+  public boolean hasMaintenanceReason(TriggeringEntity triggeringEntity) {
+    List<Map<String, String>> reasons = getMaintenanceReasons();
+    for (Map<String, String> entry : reasons) {
+      if (triggeringEntity.name().equals(entry.get(MaintenanceSignalProperty.TRIGGERED_BY.name()))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Gets the maintenance reason details for a specific triggering entity.
+   *
+   * @param triggeringEntity The entity to get reason details for
+   * @return Map containing reason details, or null if not found
+   */
+  public Map<String, String> getMaintenanceReasonDetails(TriggeringEntity triggeringEntity) {
+    List<Map<String, String>> reasons = getMaintenanceReasons();
+    for (Map<String, String> entry : reasons) {
+      if (triggeringEntity.name().equals(entry.get(MaintenanceSignalProperty.TRIGGERED_BY.name()))) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Gets the number of active maintenance reasons.
+   *
+   * @return The count of active maintenance reasons
+   */
+  public int getMaintenanceReasonsCount() {
+    return getMaintenanceReasons().size();
+  }
+
+  /**
+   * Gets the maintenance reason from a specific triggering entity.
+   *
+   * @param triggeringEntity The entity to get reason for
+   * @return The reason string, or null if not found
+   */
+  public String getMaintenanceReason(TriggeringEntity triggeringEntity) {
+    Map<String, String> details = getMaintenanceReasonDetails(triggeringEntity);
+    return details != null ? details.get(PauseSignalProperty.REASON.name()) : null;
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
@@ -447,7 +447,6 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
    * Test that automation triggered maintenance mode works correctly
    * and multi-actor maintenance mode requires all actors to exit
    */
-//  @Test(dependsOnMethods = "testMaintenanceHistory")
   @Test
   public void testAutomationMaintenanceMode() throws Exception {
     // Make sure we're not in maintenance mode at the start
@@ -501,7 +500,6 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
   /**
    * Test that removing a maintenance reason doesn't add duplicate entries in the reasons list
    */
-//  @Test(dependsOnMethods = "testAutomationMaintenanceMode")
   @Test
   public void testRemoveMaintenanceReasonNoDuplicates() throws Exception {
     // Make sure we start clean

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
@@ -21,7 +21,6 @@ package org.apache.helix.integration.controller;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -444,553 +443,766 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
   }
 
   /**
-   * Test that automation triggered maintenance mode works correctly
-   * and multi-actor maintenance mode requires all actors to exit
+   * Test basic multi-actor stacking behavior.
+   * Verifies core functionality: actor-based stacking, actor override, simpleFields most recent
    */
   @Test
   public void testAutomationMaintenanceMode() throws Exception {
-    // Make sure we're not in maintenance mode at the start
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
-
-    // Put cluster in maintenance mode via automation
-    Map<String, String> customFields = ImmutableMap.of("TICKET", "AUTO-123", "SOURCE", "HelixACM");
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
-        "Automation maintenance", customFields);
-
-    // Verify we are in maintenance mode with the right attributes
-    MaintenanceSignal maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertNotNull(maintenanceSignal);
-    Assert.assertEquals(maintenanceSignal.getTriggeringEntity(),
-        MaintenanceSignal.TriggeringEntity.AUTOMATION);
-
-    // Verify custom fields were set
-    for (Map.Entry<String, String> entry : customFields.entrySet()) {
-      Assert.assertEquals(maintenanceSignal.getRecord().getSimpleField(entry.getKey()),
-          entry.getValue());
-    }
-
-    // Manually put the cluster in maintenance too - this should keep both reasons
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
-        "User maintenance", null);
-
-    // Verify we have both reasons
-    maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertTrue(maintenanceSignal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
-    Assert.assertTrue(maintenanceSignal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-    Assert.assertEquals(maintenanceSignal.getMaintenanceReasonsCount(), 2);
-
-    // Exit maintenance mode for USER only
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-
-    // Verify we're still in maintenance mode with only AUTOMATION reason
-    maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertNotNull(maintenanceSignal);
-    Assert.assertFalse(maintenanceSignal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-    Assert.assertTrue(maintenanceSignal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
-    Assert.assertEquals(maintenanceSignal.getMaintenanceReasonsCount(), 1);
-
-    // Exit maintenance mode for AUTOMATION
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-
-    // Verify we're now out of maintenance mode
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
-  }
-
-  /**
-   * Test that removing a maintenance reason doesn't add duplicate entries in the reasons list
-   */
-  @Test
-  public void testRemoveMaintenanceReasonNoDuplicates() throws Exception {
-    // Make sure we start clean
+    ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+    _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
     _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
     _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
     TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
 
-    // First put the cluster in maintenance mode via USER
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
-        "User entry", null);
+    // Step 1: USER enters MM (t1) with reason_A
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true, "reason_A", null);
 
-    // Then add AUTOMATION reason
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
-        "Automation entry", null);
-
-    // Verify we have both reasons
-    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
-
-    // Remove AUTOMATION reason
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-
-    // Verify we only have USER reason and no duplicate entries
-    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
-
-    // Verify the reasons list field to ensure no duplicates
-    List<String> reasonsList = signal.getRecord().getListField("reasons");
-    Assert.assertEquals(reasonsList.size(), 1, "Should have exactly 1 entry in reasons list");
-
-    // Verify the simple fields are correct
-    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
-    Assert.assertEquals(signal.getReason(), "User entry");
-
-    // Remove USER reason
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-
-    // Verify we're out of maintenance mode
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
-  }
-
-  /**
-   * Test that the code can handle an old client that writes a MaintenanceSignal
-   * without using the multi-actor maintenance API (no reasons list).
-   */
-  @Test
-  public void testLegacyClientCompatibility() throws Exception {
-    // Simulate an old client by creating a MaintenanceSignal with only simple fields
-    ZNRecord record = new ZNRecord("maintenance");
-    // Add just the simple fields like an old client would
-    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "Legacy client reason");
-    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TRIGGERED_BY.name(),
-        MaintenanceSignal.TriggeringEntity.USER.name());
-    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TIMESTAMP.name(),
-        String.valueOf(System.currentTimeMillis()));
-
-    // Write it directly to ZK
-    _dataAccessor.setProperty(_keyBuilder.maintenance(), new MaintenanceSignal(record));
-
-    // Verify the maintenance signal is there
-    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertNotNull(signal);
-    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
-    Assert.assertEquals(signal.getReason(), "Legacy client reason");
-
-    // Verify that the list field does not exist yet
-    List<String> reasonsListBefore = signal.getRecord().getListField("reasons");
-    Assert.assertNull(reasonsListBefore, "Should not have reasons list field yet");
-
-    // Explicitly call reconcileMaintenanceData
-    boolean updated = signal.reconcileMaintenanceData();
-    Assert.assertTrue(updated, "Should have updated the ZNode during reconciliation");
-
-    // Verify the reasons list was created
-    List<String> reasonsListAfter = signal.getRecord().getListField("reasons");
-    Assert.assertNotNull(reasonsListAfter, "Should have created reasons list field");
-    Assert.assertEquals(reasonsListAfter.size(), 1, "Should have added exactly one entry");
-
-    // Verify the entry content contains all simple fields
-    String entryString = reasonsListAfter.get(0);
-    Assert.assertTrue(entryString.contains("Legacy client reason"),
-        "Entry should contain the reason text");
-    Assert.assertTrue(entryString.contains(MaintenanceSignal.TriggeringEntity.USER.name()),
-        "Entry should contain the entity");
-
-    // Save to ZK
-    _dataAccessor.setProperty(_keyBuilder.maintenance(), signal);
-
-    // Now read it back to verify persistence
-    MaintenanceSignal readBackSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    List<String> persistedReasonsList = readBackSignal.getRecord().getListField("reasons");
-    Assert.assertEquals(persistedReasonsList.size(), 1, "Should have persisted exactly one entry");
-
-    // Now try to add a new reason via the new API - should work with the legacy format
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
-        "Automation entry with legacy client", null);
-
-    // Verify both reasons exist
-    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
-
-    // Try removing the automation reason
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-
-    // Verify only USER reason remains
-    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-
-    // Clean up
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
-  }
-
-  /**
-   * Test that the IN_MAINTENANCE_AFTER_OPERATION field in the history record
-   * is only set to false when all maintenance reasons are gone.
-   */
-  @Test(dependsOnMethods = "testLegacyClientCompatibility")
-  public void testMaintenanceHistoryAfterOperationFlag() throws Exception {
-    // Make sure we start clean
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
-
-    // First put the cluster in maintenance mode via USER
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
-        "User entry2", null);
-
-    // Verify history shows IN_MAINTENANCE_AFTER_OPERATION as true
-    ControllerHistory history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
-    Map<String, String> lastEntry = convertStringToMap(
-        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
-    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "ENTER");
-    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "USER");
-    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
-
-    // Add a second actor (AUTOMATION)
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
-        "Automation entry2", null);
-
-    // Verify history shows IN_MAINTENANCE_AFTER_OPERATION as true
-    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
-    lastEntry = convertStringToMap(
-        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
-    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "ENTER");
-    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "AUTOMATION");
-    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
-
-    // Remove AUTOMATION actor, but we should still be in maintenance mode because USER remains
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false,
-        null, null);
-
-    // Verify we're still in maintenance mode with a single actor
     MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
     Assert.assertNotNull(signal);
     Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+    Assert.assertEquals(signal.getReason(), "reason_A");
     Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER), "reason_A");
 
-    // Verify history shows IN_MAINTENANCE_AFTER_OPERATION as true
-    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
-    lastEntry = convertStringToMap(
-        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
-    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
-    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "AUTOMATION");
-    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
+    Thread.sleep(10); // Ensure different timestamps
 
-    // Remove USER actor, which should get us out of maintenance mode
+    // Step 2: AUTOMATION enters MM (t2) with reason_B - should stack with USER
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true, "reason_B", null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.AUTOMATION); // Most recent
+    Assert.assertEquals(signal.getReason(), "reason_B"); // Most recent
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER), "reason_A");
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION), "reason_B");
+
+    Thread.sleep(10);
+
+    // Step 3: USER enters MM again (t3) with reason_C - should override previous USER entry
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_C", null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2); // Still only 2 (USER overrode itself)
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER); // Most recent
+    Assert.assertEquals(signal.getReason(), "reason_C"); // Most recent
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER),
+        "reason_C"); // Updated
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION),
+        "reason_B"); // Unchanged
+
+    Thread.sleep(10);
+
+    // Step 4: AUTOMATION enters MM again (t4) with reason_D - should override previous AUTOMATION entry
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_D", null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2); // Still only 2 (AUTOMATION overrode itself)
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.AUTOMATION); // Most recent
+    Assert.assertEquals(signal.getReason(), "reason_D"); // Most recent
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER),
+        "reason_C"); // Unchanged
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION),
+        "reason_D"); // Updated
+
+    // Clean exit sequence: actors exit in order
     _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
         null, null);
 
-    // Verify we're out of maintenance mode
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+    Assert.assertEquals(signal.getReason(), "reason_D"); // Updated to remaining reason
 
-    // Verify history shows IN_MAINTENANCE_AFTER_OPERATION as false
-    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
-    lastEntry = convertStringToMap(
-        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
-    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
-    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "USER");
-    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "false");
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null,
+        null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
   }
 
   /**
-   * Set up the initial state and mock components for maintenance mode tests.
-   * This ensures maintenance mode doesn't get automatically exited.
+   * USER administrative override after old client data loss
+   * 1. Multi-actor setup with CONTROLLER, USER, AUTOMATION
+   * 2. Old client wipes listField data (keeps only simpleFields)
+   * 3. AUTOMATION tries to exit MM (no-op since its data was wiped)
+   * 4. USER exits MM (administrative override - forces complete exit)
    */
-  private void setupMaintenanceModeTest() throws Exception {
-    // Set cluster config to ensure auto-exit conditions are never met
+  @Test
+  public void testLegacyClientCompatibility() throws Exception {
     ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
-    clusterConfig.setMaxOfflineInstancesAllowed(2);
-    clusterConfig.setNumOfflineInstancesForAutoExit(1);
+    clusterConfig.setMaxPartitionsPerInstance(-1);
+    clusterConfig.setNumOfflineInstancesForAutoExit(-1); // Disable auto-exit to prevent race conditions
     _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
 
-    // Kill 3 instances
-    for (int i = 0; i < 3; i++) {
-      _participants[i].syncStop();
-    }
-    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).isEmpty(), 2000L);
+    // Wait for config to be applied
+    TestHelper.verify(() -> {
+      ClusterConfig currentConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+      return currentConfig.getNumOfflineInstancesForAutoExit() == -1;
+    }, 2000L);
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_A", null);
+    Thread.sleep(10);
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(CLUSTER_NAME, true, "reason_B",
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
+    Thread.sleep(10);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_C", null);
 
-    // Check that the cluster is in maintenance
-    MaintenanceSignal maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertNotNull(maintenanceSignal);
+    // Verify multi-actor setup
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 3);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Simulate old client wiping listField data (only keeps simpleFields)
+    Thread.sleep(10);
+    ZNRecord record = new ZNRecord("maintenance");
+    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "reason_D");
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TIMESTAMP.name(),
+        String.valueOf(System.currentTimeMillis()));
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TRIGGERED_BY.name(),
+        MaintenanceSignal.TriggeringEntity.USER.name());
+    // Old client doesn't set listField - simulates wiping all listField data
+    _dataAccessor.setProperty(_keyBuilder.maintenance(), new MaintenanceSignal(record));
+
+    // Verify old client wiped listField data but simpleFields remain
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0,
+        "Old client should have wiped listField data");
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+    Assert.assertEquals(signal.getReason(), "reason_D");
+    Assert.assertFalse(signal.hasMaintenanceReasons(),
+        "Should have no listField reasons after old client wipe");
+
+    // AUTOMATION tries to exit MM -> should be no-op because its entry was wiped
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+
+    // Verify maintenance signal remains the same (no-op)
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal, "Should still be in maintenance after AUTOMATION no-op");
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0);
+    Assert.assertEquals(signal.getReason(), "reason_D");
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+
+    // USER tries to exit MM -> should trigger administrative override and delete maintenance ZNode
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null,
+        null);
+
+    // Verify we're completely out of maintenance mode due to USER administrative override
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
   }
 
   /**
    * Helper method to set up a common scenario for maintenance mode tests:
-   * 1. Controller enters maintenance mode
-   * 2. User A enters maintenance mode
+   * 1. USER enters maintenance mode
+   * 2. AUTOMATION enters maintenance mode
    * 3. User B enters maintenance mode (overrides User A)
-   * 4. Automation enters maintenance mode
-   * 5. Old client enters maintenance mode (simple fields only)
-   *
+   * 4. Old client enters maintenance mode (simple fields only - wipes listField data)
    */
   private void setupMultiActorMaintenanceScenario() throws Exception {
-    // Set up the maintenance mode test environment
-    setupMaintenanceModeTest();
+    ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setMaxPartitionsPerInstance(-1);
+    clusterConfig.setNumOfflineInstancesForAutoExit(-1); // Disable auto-exit to prevent race conditions
+    _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
+    // Step 0: CONTROLLER puts the cluster into MM (t1)
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_Controller",
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
 
-    // Verify maintenance signal with CONTROLLER reason only
+    // Verify maintenance signal with USER reason only
     MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
     Assert.assertNotNull(signal);
     Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
     Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.CONTROLLER);
 
-    // Step 2: USER (UserA) puts the cluster into MM (t2)
+    // Step 1: USER (UserA) puts the cluster into MM (t1)
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_A", null);
+
+    // Verify maintenance signal with USER reason only
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+
+    // Step 2: AUTOMATION puts the cluster into MM (t2)
     Thread.sleep(10); // Ensure different timestamps
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true, "reason_B", null);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_B", null);
 
     // Verify maintenance signal has both reasons
     signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-
-    // Step 3: USER (UserB) puts the cluster into MM (t3) - overrides UserA's entry
-    Thread.sleep(10);
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true, "reason_C", null);
-
-    // Verify maintenance signal still has same number of reasons but UserB's reason replaced UserA's
-    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
-    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER), "reason_C");
-
-    // Step 4: AUTOMATION (HelixACM) puts the cluster into MM (t4)
-    Thread.sleep(10);
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true, "reason_D", null);
-
-    // Verify maintenance signal has all three reasons
-    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
     Assert.assertEquals(signal.getMaintenanceReasonsCount(), 3);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
     Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
     Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
 
-    // Step 5: USER (Old Client) enters cluster into MM (t5)
+    // Step 3: USER (UserB) puts the cluster into MM (t3) - overrides UserA's entry
+    Thread.sleep(10);
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_C", null);
+
+    // Verify maintenance signal still has same number of reasons but UserB's reason replaced UserA's
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 3);
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER), "reason_C");
+
+    // Step 4: USER (Old Client) enters cluster into MM (t4)
     // Simulate old client by directly creating a MaintenanceSignal with simple fields only
+    // Per design doc: "Legacy clients use the dataAccessor.set() API to create Maintenance signals,
+    // which results in the entire ZNRecord being overwritten, including purging all existing ListField entries"
     Thread.sleep(10);
     ZNRecord record = new ZNRecord("maintenance");
-    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "reason_E");
+    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "reason_D");
     record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TIMESTAMP.name(),
         String.valueOf(System.currentTimeMillis()));
     record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TRIGGERED_BY.name(),
         MaintenanceSignal.TriggeringEntity.USER.name());
 
-    // Write directly to ZK
-    _dataAccessor.updateProperty(_keyBuilder.maintenance(), new MaintenanceSignal(record));
+    // Use setProperty (not updateProperty) to simulate old client completely overwriting the ZNode
+    _dataAccessor.setProperty(_keyBuilder.maintenance(), new MaintenanceSignal(record));
 
-    // Verify maintenance signal has updated simple fields but listField still has old USER entry
+    // Verify maintenance signal has updated simple fields but listField data was wiped by old client
     signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
     Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
-    Assert.assertEquals(signal.getReason(), "reason_E");
+    Assert.assertEquals(signal.getReason(), "reason_D");
 
-    // Verify reasons list still has original 3 entries (not updated by old client)
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 3);
+    // Verify reasons list was wiped by old client (data loss accepted by design)
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0,
+        "Old client should have wiped all listField data");
   }
 
   /**
-   * Test Case A: New clients interaction where each actor enters and exits properly
-   * 1. Each actor (User, Automation, Controller) enters maintenance mode
-   * 2. Each actor exits maintenance mode in sequence
-   * 3. Verify maintenance flags in history records
+   * Test Case A: USER administrative override after old client data loss
+   * 1. After old client wipes data, verify no listField reasons exist
+   * 2. USER tries to exit MM - should trigger administrative override and delete maintenance ZNode
+   * 3. Verify maintenance mode is completely exited
    */
   @Test
-  public void testMultiActorMaintenanceModeExitSequence() throws Exception {
+  public void testUserAdministrativeOverride() throws Exception {
     // Set up the initial state with all actors having entered maintenance mode
+    // Note: setupMultiActorMaintenanceScenario() ends with old client wiping listField data
     setupMultiActorMaintenanceScenario();
 
-    // Step 6A: USER (New client) exits MM
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-
-    // Verify USER reason is gone, but CONTROLLER and AUTOMATION remain
+    // Verify the old client has wiped the listField data
     MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
     Assert.assertNotNull(signal);
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
-    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0,
+        "Old client should have wiped listField data");
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+    Assert.assertEquals(signal.getReason(), "reason_D");
 
-    // Verify in history that we're still in maintenance
+    // Step 6A: USER (New client) tries to exit MM
+    // Since USER doesn't have an entry in listFields.reasons, this should trigger administrative override
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+
+    // Verify we're completely out of maintenance mode due to USER administrative override
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+
+    // Verify in history that we're no longer in maintenance
     ControllerHistory history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
     Map<String, String> lastEntry = convertStringToMap(
         history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
     Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
     Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "USER");
-    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
-
-    // Step 7A: AUTOMATION exits MM
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-
-    // Verify AUTOMATION reason is gone, only CONTROLLER remains
-    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertNotNull(signal);
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
-    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
-    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-
-    // Verify in history that we're still in maintenance
-    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
-    lastEntry = convertStringToMap(
-        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
-    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
-    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "AUTOMATION");
-    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
-
-    // Step 8A: CONTROLLER exits MM
-    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(
-        CLUSTER_NAME, false, null, MaintenanceSignal.AutoTriggerReason.NOT_APPLICABLE);
-
-    // Verify we're out of maintenance mode
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
-
-    // Verify in history that we're no longer in maintenance
-    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
-    lastEntry = convertStringToMap(
-        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
-    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
-    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "CONTROLLER");
     Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "false");
   }
 
   /**
-   * Test Case B: Old client enters, new clients reconcile during future operations
-   * 1. Old client enters maintenance mode without updating the reasons list
-   * 2. New client enters maintenance mode and reconciles the list
+   * Old client enters, new clients operate independently (no reconciliation)
+   * 1. Old client enters maintenance mode without updating the reasons list (data wiped)
+   * 2. New client enters maintenance mode and operates independently
    * 3. All actors exit in sequence
    */
   @Test
-  public void testMultiActorMaintenanceModeReconciliation() throws Exception {
+  public void testOldClientDataLoss() throws Exception {
     // Set up the initial state with all actors having entered maintenance mode
     setupMultiActorMaintenanceScenario();
 
-    // Step 6B: AUTOMATION enters MM again - should reconcile the old client's USER update
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true, "reason_F", null);
-
-    // Verify signal has reconciled the old client's USER update with the timestamp
+    // At this point, the old client in setupMultiActorMaintenanceScenario has wiped the listField data
+    // Verify that the old client action resulted in data loss
     MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+
+    // simpleFields should show USER data (from old client)
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+    Assert.assertEquals(signal.getReason(), "reason_D");
+
+    // But listFields.reasons should be empty (wiped by old client)
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0,
+        "Old client should have wiped listField data");
+    Assert.assertFalse(signal.hasMaintenanceReasons(),
+        "Should not have maintenance reasons after old client wipe");
+
+    // Step 6B: AUTOMATION enters MM again - should work independently (no reconciliation)
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_F", null);
+
+    // Verify signal now has only AUTOMATION reason (no reconciliation of old USER data)
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER),
+        "Controller data was lost");
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER),
+        "User data was lost");
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Verify the new AUTOMATION reason
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION),
+        "reason_F");
+
+    // Exit the only remaining actor
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null,
+        null);
+
+    // Verify we're out of maintenance mode
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test AUTOMATION re-entry after old client wipes data
+   * Old client wipes data, AUTOMATION re-enters independently,
+   * then sequence of exits with no-ops and administrative override
+   */
+  @Test
+  public void testAutomationReentryAfterDataLoss() throws Exception {
+    // Setup the multi-actor scenario which ends with old client wiping data
+    setupMultiActorMaintenanceScenario();
+
+    // Case B Step 6: AUTOMATION enters MM again (works independently, no reconciliation)
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "reason_E", null);
+
+    // Verify signal now has only AUTOMATION reason (no reconciliation of wiped data)
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION),
+        "reason_E");
+
+    // Case B Step 7: USER exits MM -> should be administrative override since USER has no listField entry
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null,
+        null);
+
+    // Verify we're completely out of maintenance mode due to USER administrative override
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test old client force exit by deleting entire maintenance znode
+   */
+  @Test
+  public void testOldClientDeletesEntireZnode() throws Exception {
+    // Setup: Multiple actors enter maintenance mode
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "user_reason", null);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "automation_reason", null);
+
+    // Verify we have both actors
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+
+    // Case D: USER (old client) exits MM by deleting entire znode
+    _dataAccessor.removeProperty(_keyBuilder.maintenance());
+
+    // Verify we're completely out of maintenance mode (all data lost)
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test that simpleFields always reflect the most recently added reason
+   */
+  @Test
+  public void testSimpleFieldsReflectMostRecent() throws Exception {
+    // Entry 1: USER at t1
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "user_first", null);
+
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getReason(), "user_first");
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+
+    Thread.sleep(10);
+
+    // Entry 2: AUTOMATION at t2 (should become most recent)
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "automation_second", null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getReason(), "automation_second");
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.AUTOMATION);
+
+    Thread.sleep(10);
+
+    // Entry 3: USER at t3 (should become most recent)
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "user_third", null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getReason(), "user_third");
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+
+    Thread.sleep(10);
+
+    // Entry 4: AUTOMATION again at t4 (should become most recent, overriding its previous entry)
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "automation_fourth", null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getReason(), "automation_fourth");
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.AUTOMATION);
+    // Should still have 2 actors (AUTOMATION entry was overwritten)
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+
+    // Clean up
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test edge cases around empty maintenance mode
+   */
+  @Test
+  public void testEmptyStateEdgeCases() throws Exception {
+    // Test 1: Try to exit when no maintenance mode exists
+
+    // AUTOMATION tries to exit when no MM exists -> should be no-op
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+    Assert.assertNull(_dataAccessor.getProperty(_keyBuilder.maintenance()));
+
+    // USER tries to exit when no MM exists -> should be no-op (nothing to override)
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+    Assert.assertNull(_dataAccessor.getProperty(_keyBuilder.maintenance()));
+
+    // Test 2: Create maintenance mode with only simpleFields (old client style)
+    ZNRecord record = new ZNRecord("maintenance");
+    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "Old client reason");
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TRIGGERED_BY.name(),
+        MaintenanceSignal.TriggeringEntity.USER.name());
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TIMESTAMP.name(),
+        String.valueOf(System.currentTimeMillis()));
+    _dataAccessor.setProperty(_keyBuilder.maintenance(), new MaintenanceSignal(record));
+
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0, "Should have no listField reasons");
+    Assert.assertFalse(signal.hasMaintenanceReasons(), "Should report no maintenance reasons");
+
+    // AUTOMATION tries to exit -> should be no-op
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+    Assert.assertNotNull(_dataAccessor.getProperty(_keyBuilder.maintenance()),
+        "Should still exist after no-op");
+
+    // USER tries to exit -> should be administrative override
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test mixed entry/exit scenarios to stress test maintenance mode stacking
+   * Verifies complex sequences of actors entering and exiting in different orders
+   */
+  @Test
+  public void testMixedEntryExitScenarios() throws Exception {
+    // Phase 1: Multiple actors enter
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "user_reason_1", null);
+    Thread.sleep(10);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "automation_reason_1", null);
+
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertEquals(signal.getReason(), "automation_reason_1"); // Most recent
+
+    // Phase 2: One actor exits, then re-enters with different reason
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null); // USER exits
+    Thread.sleep(10);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // USER re-enters with new reason
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "user_reason_2", null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertEquals(signal.getReason(), "user_reason_2"); // Most recent
+
+    // Phase 3: Clean exit
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test basic multi-actor stacking behavior including CONTROLLER entity
+   * Creates actual conditions that trigger CONTROLLER maintenance mode
+   */
+  @Test
+  public void testMultiActorStackingWithController() throws Exception {
+    ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setMaxPartitionsPerInstance(-1);
+    _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
+    // Step 1: Directly trigger CONTROLLER maintenance mode using API
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(CLUSTER_NAME, true,
+        "Test controller maintenance",
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
+
+    // Verify CONTROLLER entered maintenance mode automatically
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.CONTROLLER);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+
+    // Step 2: USER enters MM - should stack with CONTROLLER
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "user_reason", null);
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+    Assert.assertEquals(signal.getReason(), "user_reason"); // Most recent
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+
+    // Step 3: AUTOMATION enters MM - should stack with both
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "automation_reason", null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 3);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.AUTOMATION);
+    Assert.assertEquals(signal.getReason(), "automation_reason"); // Most recent
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Step 4: USER exits - should remain in maintenance with CONTROLLER and AUTOMATION
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Step 5: AUTOMATION exits - should remain in maintenance with only CONTROLLER
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Step 6: Exit CONTROLLER maintenance mode
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(CLUSTER_NAME, false, null,
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
+
+    // Verify maintenance mode is completely off
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test old client wipes data including CONTROLLER entry
+   * Verifies CONTROLLER no-op behavior after data loss
+   */
+  @Test
+  public void testControllerNoOpAfterOldClientWipe() throws Exception {
+    ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setMaxPartitionsPerInstance(-1);
+    clusterConfig.setNumOfflineInstancesForAutoExit(-1); // Disable auto-exit to prevent race conditions
+    _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
+    // Step 1: Directly trigger CONTROLLER maintenance mode using API
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(CLUSTER_NAME, true,
+        "Test controller maintenance",
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
+
+    // Verify CONTROLLER entered maintenance mode
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.CONTROLLER);
+
+    // Add USER and AUTOMATION to create multi-actor scenario
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "user_reason", null);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "automation_reason", null);
+
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
     Assert.assertEquals(signal.getMaintenanceReasonsCount(), 3);
     Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
     Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
     Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
 
-    // Verify reason is now "reason_E"
-    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER), "reason_E");
-
-    // Exit all actors in sequence
-    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(
-        CLUSTER_NAME, false, null, MaintenanceSignal.AutoTriggerReason.NOT_APPLICABLE);
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-
-    // Verify we're out of maintenance mode
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
-  }
-
-  /**
-   * Test Case C: Old client exits maintenance mode while other actors still have reasons
-   * 1. Old client bypasses the normal API and just deletes the maintenance node
-   * 2. Verify the cluster exits maintenance mode completely
-   */
-  @Test
-  public void testMultiActorMaintenanceModeOldClientExit() throws Exception {
-    // Set up the initial state with all actors having entered maintenance mode
-    setupMultiActorMaintenanceScenario();
-
-    // Step 6C: USER (old client) exits MM - simulating old client removing entire node
-    _dataAccessor.removeProperty(_keyBuilder.maintenance());
-
-    // Verify we're out of maintenance mode completely
-    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
-  }
-
-  /**
-   * Old client overrides simple fields after new clients enter MM,
-   * then new client exits but should not exit maintenance mode completely
-   * 1. AUTOMATION enters MM (new client)
-   * 2. USER enters MM again (old client - only updates simple fields)
-   * 3. AUTOMATION exits MM
-   * 4. Verify we're still in maintenance mode because USER reason remains
-   */
-  @Test
-  public void testMultiActorMaintenanceModeOldClientOverride() throws Exception {
-    // Step 1: AUTOMATION enters MM (t2)
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
-        "AUTOMATION reason", null);
-
-    // Verify maintenance signal has only AUTOMATION reason.
-    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
-    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
-
-    // Step 2: USER enters MM (t3) via old client (only updates simple fields)
-    Thread.sleep(10);
-    long t3 = System.currentTimeMillis();
-    // Simulate an old client by creating a MaintenanceSignal with only simple fields
-    ZNRecord record = new ZNRecord(signal.getRecord());
-    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "USER old client reason");
-    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TIMESTAMP.name(), String.valueOf(t3));
+    // Simulate old client wiping all data
+    ZNRecord record = new ZNRecord("maintenance");
+    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "Old client reason");
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TIMESTAMP.name(),
+        String.valueOf(System.currentTimeMillis()));
     record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TRIGGERED_BY.name(),
         MaintenanceSignal.TriggeringEntity.USER.name());
-    // Don't update the listField - simulate old client behavior
-
-    // Write it directly to ZK
+    // Old client doesn't set listField - simulates wiping all listField data
     _dataAccessor.setProperty(_keyBuilder.maintenance(), new MaintenanceSignal(record));
 
-    // Verify the simple fields were updated but the reasons list still has old USER entry
+    // Verify old client wiped listField data
     signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0,
+        "Old client should have wiped listField data");
     Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
-    Assert.assertEquals(signal.getReason(), "USER old client reason");
 
-    // MaintenanceReasonsCount should still be 2 because the old client didn't update the reasons list
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    // Try CONTROLLER exit - should be no-op since its entry was wiped
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(CLUSTER_NAME, false, null,
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
 
-    // Step 3: AUTOMATION exits MM
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
-
-    // Verify we're still in maintenance mode because USER reason remains
+    // Verify maintenance signal remains the same (no-op)
     signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertNotNull(signal);
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
-    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+    Assert.assertNotNull(signal, "Should still be in maintenance after CONTROLLER no-op");
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0);
+    Assert.assertEquals(signal.getReason(), "Old client reason");
 
-    // Check that simple fields were updated to USER values
-    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
-    Assert.assertEquals(signal.getReason(), "USER old client reason");
+    // Try AUTOMATION exit - should also be no-op since its entry was wiped
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
 
-    // Clean up
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    // Verify maintenance signal remains the same (no-op)
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal, "Should still be in maintenance after AUTOMATION no-op");
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0);
+    Assert.assertEquals(signal.getReason(), "Old client reason");
+
+    // USER tries to exit -> should be administrative override
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+
+    // Verify completely out of maintenance mode
     TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
   }
 
   /**
-   * Entity tries to exit MM without having entered it
-   * 1. AUTOMATION enters MM
-   * 2. USER tries to exit MM (shouldn't affect MM state)
-   * 3. Verify we're still in maintenance mode because USER wasn't an actor
-   * 4. AUTOMATION exits MM
-   * 5. Verify we're out of maintenance mode
+   * Test CONTROLLER override behavior - same entity overwrites previous entry
    */
   @Test
-  public void testMultiActorMaintenanceModeInvalidExit() throws Exception {
-    // Step 1: AUTOMATION enters MM
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true, "AUTOMATION reason", null);
+  public void testControllerOverrideBehavior() throws Exception {
+    ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setMaxPartitionsPerInstance(-1);
+    _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
+    // Step 1: Directly trigger CONTROLLER maintenance mode with specific auto-trigger reason
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(CLUSTER_NAME, true,
+        "Initial controller reason",
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
 
-    // Verify maintenance signal with AUTOMATION reason
+    // Verify CONTROLLER entered with auto-trigger reason
     MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
     Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.CONTROLLER);
+    Assert.assertEquals(signal.getAutoTriggerReason(),
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
     Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
 
-    // Step 2: USER tries to exit MM (shouldn't affect MM state)
-    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    // Manually trigger CONTROLLER entry again with different reason (to test override)
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(CLUSTER_NAME, true,
+        "manual_controller_reason",
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
 
-    // Step 3: Verify we're still in maintenance mode
     signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
-    Assert.assertNotNull(signal);
-    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
-    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.CONTROLLER);
+    Assert.assertEquals(signal.getAutoTriggerReason(),
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(),
+        1); // Should still be only 1 (CONTROLLER overrode itself)
 
-    // Step 4: AUTOMATION exits MM
-    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    // Add another actor to verify stacking still works
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "user_reason", null);
 
-    // Step 5: Verify we're out of maintenance mode
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+
+    // Cleanup
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(CLUSTER_NAME, false,
+        null,
+        MaintenanceSignal.AutoTriggerReason.MAX_INSTANCES_UNABLE_TO_ACCEPT_ONLINE_REPLICAS);
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
     TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test reconciliation of legacy USER data when new client adds reason
+   * Verifies the critical design requirement to preserve old client data
+   */
+  @Test
+  public void testReconciliationOfLegacyUserData() throws Exception {
+    // Step 1: Old client sets simpleFields only (no listFields)
+    ZNRecord record = new ZNRecord("maintenance");
+    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "legacy_user_reason");
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TRIGGERED_BY.name(),
+        MaintenanceSignal.TriggeringEntity.USER.name());
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TIMESTAMP.name(),
+        String.valueOf(System.currentTimeMillis()));
+    _dataAccessor.setProperty(_keyBuilder.maintenance(), new MaintenanceSignal(record));
+
+    // Verify old client state (no listFields reasons)
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 0,
+        "Old client should have no listField data");
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+    Assert.assertEquals(signal.getReason(), "legacy_user_reason");
+
+    // Step 2: New client adds AUTOMATION reason - should trigger reconciliation
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "automation_reason", null);
+
+    // Step 3: Verify both reasons are preserved after reconciliation
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2,
+        "Should have both reconciled USER and new AUTOMATION reasons");
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER),
+        "USER reason should be preserved");
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION),
+        "AUTOMATION reason should be added");
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER),
+        "legacy_user_reason");
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION),
+        "automation_reason");
+
+    // Cleanup
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME,
+        false, null, null);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME,
+        false, null, null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null,
+        2000L);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
@@ -20,7 +20,9 @@ package org.apache.helix.integration.controller;
  */
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -40,11 +42,13 @@ import org.apache.helix.model.ControllerHistory;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.MaintenanceSignal;
+import org.apache.helix.model.PauseSignal;
 import org.apache.helix.monitoring.mbeans.MonitorDomainNames;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 
 import static org.apache.helix.monitoring.mbeans.ClusterStatusMonitor.CLUSTER_DN_KEY;
 
@@ -438,5 +442,462 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
   private static Map<String, String> convertStringToMap(String value) throws IOException {
     return new ObjectMapper().readValue(value,
         TypeFactory.defaultInstance().constructMapType(HashMap.class, String.class, String.class));
+  }
+
+  /**
+   * Test that automation triggered maintenance mode works correctly
+   * and multi-actor maintenance mode requires all actors to exit
+   */
+//  @Test(dependsOnMethods = "testMaintenanceHistory")
+  @Test
+  public void testAutomationMaintenanceMode() throws Exception {
+    // Make sure we're not in maintenance mode at the start
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+
+    // Put cluster in maintenance mode via automation
+    Map<String, String> customFields = ImmutableMap.of("TICKET", "AUTO-123", "SOURCE", "HelixACM");
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "Automation maintenance", customFields);
+
+    // Verify we are in maintenance mode with the right attributes
+    MaintenanceSignal maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(maintenanceSignal);
+    Assert.assertEquals(maintenanceSignal.getTriggeringEntity(),
+        MaintenanceSignal.TriggeringEntity.AUTOMATION);
+
+    // Verify custom fields were set
+    for (Map.Entry<String, String> entry : customFields.entrySet()) {
+      Assert.assertEquals(maintenanceSignal.getRecord().getSimpleField(entry.getKey()),
+          entry.getValue());
+    }
+
+    // Manually put the cluster in maintenance too - this should keep both reasons
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "User maintenance", null);
+
+    // Verify we have both reasons
+    maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertTrue(maintenanceSignal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+    Assert.assertTrue(maintenanceSignal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertEquals(maintenanceSignal.getMaintenanceReasonsCount(), 2);
+
+    // Exit maintenance mode for USER only
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    // Verify we're still in maintenance mode with only AUTOMATION reason
+    maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(maintenanceSignal);
+    Assert.assertFalse(maintenanceSignal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(maintenanceSignal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+    Assert.assertEquals(maintenanceSignal.getMaintenanceReasonsCount(), 1);
+
+    // Exit maintenance mode for AUTOMATION
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    // Verify we're now out of maintenance mode
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test that removing a maintenance reason doesn't add duplicate entries in the reasons list
+   */
+//  @Test(dependsOnMethods = "testAutomationMaintenanceMode")
+  @Test
+  public void testRemoveMaintenanceReasonNoDuplicates() throws Exception {
+    // Make sure we start clean
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+
+    // First put the cluster in maintenance mode via USER
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "User entry", null);
+
+    // Then add AUTOMATION reason
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "Automation entry", null);
+
+    // Verify we have both reasons
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Remove AUTOMATION reason
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    // Verify we only have USER reason and no duplicate entries
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Verify the reasons list field to ensure no duplicates
+    List<String> reasonsList = signal.getRecord().getListField("reasons");
+    Assert.assertEquals(reasonsList.size(), 1, "Should have exactly 1 entry in reasons list");
+
+    // Verify the simple fields are correct
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+    Assert.assertEquals(signal.getReason(), "User entry");
+
+    // Remove USER reason
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    // Verify we're out of maintenance mode
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test that the code can handle an old client that writes a MaintenanceSignal
+   * without using the multi-actor maintenance API (no reasons list).
+   */
+  @Test
+  public void testLegacyClientCompatibility() throws Exception {
+    // Simulate an old client by creating a MaintenanceSignal with only simple fields
+    ZNRecord record = new ZNRecord("maintenance");
+    // Add just the simple fields like an old client would
+    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "Legacy client reason");
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TRIGGERED_BY.name(),
+        MaintenanceSignal.TriggeringEntity.USER.name());
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TIMESTAMP.name(),
+        String.valueOf(System.currentTimeMillis()));
+
+    // Write it directly to ZK
+    _dataAccessor.setProperty(_keyBuilder.maintenance(), new MaintenanceSignal(record));
+
+    // Verify the maintenance signal is there
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+    Assert.assertEquals(signal.getReason(), "Legacy client reason");
+
+    // Verify that the list field does not exist yet
+    List<String> reasonsListBefore = signal.getRecord().getListField("reasons");
+    Assert.assertNull(reasonsListBefore, "Should not have reasons list field yet");
+
+    // Explicitly call reconcileMaintenanceData
+    boolean updated = signal.reconcileMaintenanceData();
+    Assert.assertTrue(updated, "Should have updated the ZNode during reconciliation");
+
+    // Verify the reasons list was created
+    List<String> reasonsListAfter = signal.getRecord().getListField("reasons");
+    Assert.assertNotNull(reasonsListAfter, "Should have created reasons list field");
+    Assert.assertEquals(reasonsListAfter.size(), 1, "Should have added exactly one entry");
+
+    // Verify the entry content contains all simple fields
+    String entryString = reasonsListAfter.get(0);
+    Assert.assertTrue(entryString.contains("Legacy client reason"),
+        "Entry should contain the reason text");
+    Assert.assertTrue(entryString.contains(MaintenanceSignal.TriggeringEntity.USER.name()),
+        "Entry should contain the entity");
+
+    // Save to ZK
+    _dataAccessor.setProperty(_keyBuilder.maintenance(), signal);
+
+    // Now read it back to verify persistence
+    MaintenanceSignal readBackSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    List<String> persistedReasonsList = readBackSignal.getRecord().getListField("reasons");
+    Assert.assertEquals(persistedReasonsList.size(), 1, "Should have persisted exactly one entry");
+
+    // Now try to add a new reason via the new API - should work with the legacy format
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "Automation entry with legacy client", null);
+
+    // Verify both reasons exist
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Try removing the automation reason
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    // Verify only USER reason remains
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+
+    // Clean up
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test that the IN_MAINTENANCE_AFTER_OPERATION field in the history record
+   * is only set to false when all maintenance reasons are gone.
+   */
+  @Test(dependsOnMethods = "testLegacyClientCompatibility")
+  public void testMaintenanceHistoryAfterOperationFlag() throws Exception {
+    // Make sure we start clean
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+
+    // First put the cluster in maintenance mode via USER
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true,
+        "User entry2", null);
+
+    // Verify history shows IN_MAINTENANCE_AFTER_OPERATION as true
+    ControllerHistory history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
+    Map<String, String> lastEntry = convertStringToMap(
+        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
+    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "ENTER");
+    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "USER");
+    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
+
+    // Add a second actor (AUTOMATION)
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
+        "Automation entry2", null);
+
+    // Verify history shows IN_MAINTENANCE_AFTER_OPERATION as true
+    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
+    lastEntry = convertStringToMap(
+        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
+    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "ENTER");
+    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "AUTOMATION");
+    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
+
+    // Remove AUTOMATION actor, but we should still be in maintenance mode because USER remains
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+
+    // Verify we're still in maintenance mode with a single actor
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+
+    // Verify history shows IN_MAINTENANCE_AFTER_OPERATION as true
+    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
+    lastEntry = convertStringToMap(
+        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
+    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
+    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "AUTOMATION");
+    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
+
+    // Remove USER actor, which should get us out of maintenance mode
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false,
+        null, null);
+
+    // Verify we're out of maintenance mode
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+
+    // Verify history shows IN_MAINTENANCE_AFTER_OPERATION as false
+    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
+    lastEntry = convertStringToMap(
+        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
+    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
+    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "USER");
+    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "false");
+  }
+
+  /**
+   * Set up the initial state and mock components for maintenance mode tests.
+   * This ensures maintenance mode doesn't get automatically exited.
+   */
+  private void setupMaintenanceModeTest() throws Exception {
+    // Set cluster config to ensure auto-exit conditions are never met
+    ClusterConfig clusterConfig = _manager.getConfigAccessor().getClusterConfig(CLUSTER_NAME);
+    clusterConfig.setMaxOfflineInstancesAllowed(2);
+    clusterConfig.setNumOfflineInstancesForAutoExit(1);
+    _manager.getConfigAccessor().setClusterConfig(CLUSTER_NAME, clusterConfig);
+
+    // Kill 3 instances
+    for (int i = 0; i < 3; i++) {
+      _participants[i].syncStop();
+    }
+    TestHelper.verify(() -> _dataAccessor.getChildNames(_keyBuilder.liveInstances()).isEmpty(), 2000L);
+
+    // Check that the cluster is in maintenance
+    MaintenanceSignal maintenanceSignal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(maintenanceSignal);
+  }
+
+  /**
+   * Helper method to set up a common scenario for maintenance mode tests:
+   * 1. Controller enters maintenance mode
+   * 2. User A enters maintenance mode
+   * 3. User B enters maintenance mode (overrides User A)
+   * 4. Automation enters maintenance mode
+   * 5. Old client enters maintenance mode (simple fields only)
+   *
+   */
+  private void setupMultiActorMaintenanceScenario() throws Exception {
+    // Set up the maintenance mode test environment
+    setupMaintenanceModeTest();
+
+    // Verify maintenance signal with CONTROLLER reason only
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.CONTROLLER);
+
+    // Step 2: USER (UserA) puts the cluster into MM (t2)
+    Thread.sleep(10); // Ensure different timestamps
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true, "reason_B", null);
+
+    // Verify maintenance signal has both reasons
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+
+    // Step 3: USER (UserB) puts the cluster into MM (t3) - overrides UserA's entry
+    Thread.sleep(10);
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, true, "reason_C", null);
+
+    // Verify maintenance signal still has same number of reasons but UserB's reason replaced UserA's
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER), "reason_C");
+
+    // Step 4: AUTOMATION (HelixACM) puts the cluster into MM (t4)
+    Thread.sleep(10);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true, "reason_D", null);
+
+    // Verify maintenance signal has all three reasons
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 3);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Step 5: USER (Old Client) enters cluster into MM (t5)
+    // Simulate old client by directly creating a MaintenanceSignal with simple fields only
+    Thread.sleep(10);
+    ZNRecord record = new ZNRecord("maintenance");
+    record.setSimpleField(PauseSignal.PauseSignalProperty.REASON.name(), "reason_E");
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TIMESTAMP.name(),
+        String.valueOf(System.currentTimeMillis()));
+    record.setSimpleField(MaintenanceSignal.MaintenanceSignalProperty.TRIGGERED_BY.name(),
+        MaintenanceSignal.TriggeringEntity.USER.name());
+
+    // Write directly to ZK
+    _dataAccessor.updateProperty(_keyBuilder.maintenance(), new MaintenanceSignal(record));
+
+    // Verify maintenance signal has updated simple fields but listField still has old USER entry
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getTriggeringEntity(), MaintenanceSignal.TriggeringEntity.USER);
+    Assert.assertEquals(signal.getReason(), "reason_E");
+
+    // Verify reasons list still has original 3 entries (not updated by old client)
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 3);
+  }
+
+  /**
+   * Test Case A: New clients interaction where each actor enters and exits properly
+   * 1. Each actor (User, Automation, Controller) enters maintenance mode
+   * 2. Each actor exits maintenance mode in sequence
+   * 3. Verify maintenance flags in history records
+   */
+  @Test
+  public void testMultiActorMaintenanceModeExitSequence() throws Exception {
+    // Set up the initial state with all actors having entered maintenance mode
+    setupMultiActorMaintenanceScenario();
+
+    // Step 6A: USER (New client) exits MM
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    // Verify USER reason is gone, but CONTROLLER and AUTOMATION remain
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 2);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+
+    // Verify in history that we're still in maintenance
+    ControllerHistory history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
+    Map<String, String> lastEntry = convertStringToMap(
+        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
+    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
+    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "USER");
+    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
+
+    // Step 7A: AUTOMATION exits MM
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    // Verify AUTOMATION reason is gone, only CONTROLLER remains
+    signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertNotNull(signal);
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 1);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+    Assert.assertFalse(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+
+    // Verify in history that we're still in maintenance
+    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
+    lastEntry = convertStringToMap(
+        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
+    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
+    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "AUTOMATION");
+    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "true");
+
+    // Step 8A: CONTROLLER exits MM
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(
+        CLUSTER_NAME, false, null, MaintenanceSignal.AutoTriggerReason.NOT_APPLICABLE);
+
+    // Verify we're out of maintenance mode
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+
+    // Verify in history that we're no longer in maintenance
+    history = _dataAccessor.getProperty(_keyBuilder.controllerLeaderHistory());
+    lastEntry = convertStringToMap(
+        history.getMaintenanceHistoryList().get(history.getMaintenanceHistoryList().size() - 1));
+    Assert.assertEquals(lastEntry.get("OPERATION_TYPE"), "EXIT");
+    Assert.assertEquals(lastEntry.get("TRIGGERED_BY"), "CONTROLLER");
+    Assert.assertEquals(lastEntry.get("IN_MAINTENANCE_AFTER_OPERATION"), "false");
+  }
+
+  /**
+   * Test Case B: Old client enters, new clients reconcile during future operations
+   * 1. Old client enters maintenance mode without updating the reasons list
+   * 2. New client enters maintenance mode and reconciles the list
+   * 3. All actors exit in sequence
+   */
+  @Test
+  public void testMultiActorMaintenanceModeReconciliation() throws Exception {
+    // Set up the initial state with all actors having entered maintenance mode
+    setupMultiActorMaintenanceScenario();
+
+    // Step 6B: AUTOMATION enters MM again - should reconcile the old client's USER update
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true, "reason_F", null);
+
+    // Verify signal has reconciled the old client's USER update with the timestamp
+    MaintenanceSignal signal = _dataAccessor.getProperty(_keyBuilder.maintenance());
+    Assert.assertEquals(signal.getMaintenanceReasonsCount(), 3);
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.CONTROLLER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER));
+    Assert.assertTrue(signal.hasMaintenanceReason(MaintenanceSignal.TriggeringEntity.AUTOMATION));
+
+    // Verify reason is now "reason_E"
+    Assert.assertEquals(signal.getMaintenanceReason(MaintenanceSignal.TriggeringEntity.USER), "reason_E");
+
+    // Exit all actors in sequence
+    _gSetupTool.getClusterManagementTool().autoEnableMaintenanceMode(
+        CLUSTER_NAME, false, null, MaintenanceSignal.AutoTriggerReason.NOT_APPLICABLE);
+    _gSetupTool.getClusterManagementTool().manuallyEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+    _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, false, null, null);
+
+    // Verify we're out of maintenance mode
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
+  }
+
+  /**
+   * Test Case C: Old client exits maintenance mode while other actors still have reasons
+   * 1. Old client bypasses the normal API and just deletes the maintenance node
+   * 2. Verify the cluster exits maintenance mode completely
+   */
+  @Test
+  public void testMultiActorMaintenanceModeOldClientExit() throws Exception {
+    // Set up the initial state with all actors having entered maintenance mode
+    setupMultiActorMaintenanceScenario();
+
+    // Step 6C: USER (old client) exits MM - simulating old client removing entire node
+    _dataAccessor.removeProperty(_keyBuilder.maintenance());
+
+    // Verify we're out of maintenance mode completely
+    TestHelper.verify(() -> _dataAccessor.getProperty(_keyBuilder.maintenance()) == null, 2000L);
   }
 }

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
@@ -20,7 +20,6 @@ package org.apache.helix.integration.controller;
  */
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
+++ b/helix-core/src/test/java/org/apache/helix/integration/controller/TestClusterMaintenanceMode.java
@@ -909,7 +909,6 @@ public class TestClusterMaintenanceMode extends TaskTestBase {
   @Test
   public void testMultiActorMaintenanceModeOldClientOverride() throws Exception {
     // Step 1: AUTOMATION enters MM (t2)
-    Thread.sleep(10); // Ensure different timestamps
     _gSetupTool.getClusterManagementTool().automationEnableMaintenanceMode(CLUSTER_NAME, true,
         "AUTOMATION reason", null);
 

--- a/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
+++ b/helix-core/src/test/java/org/apache/helix/mock/MockHelixAdmin.java
@@ -365,6 +365,12 @@ public class MockHelixAdmin implements HelixAdmin {
   }
 
   @Override
+  public void automationEnableMaintenanceMode(String clusterName, boolean enabled, String reason,
+      Map<String, String> customFields) {
+
+  }
+
+  @Override
   public boolean isInMaintenanceMode(String clusterName) {
     return false;
   }

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -338,15 +338,12 @@ public class ClusterAccessor extends AbstractHelixResource {
           // NOP
         }
 
-        // Filter out isAutomation and reason keys from customFieldsMap as they are already handled as
-        // TriggeringEntity and REASON
         if (customFieldsMap != null) {
           customFieldsMap.entrySet().removeIf(entry ->
               "isAutomation".equalsIgnoreCase(entry.getKey()) ||
                   "reason".equalsIgnoreCase(entry.getKey()));
         }
 
-        // Choose the appropriate method based on the triggering entity
         if (isAutomationTriggered) {
           helixAdmin
               .automationEnableMaintenanceMode(clusterId, command == Command.enableMaintenanceMode,

--- a/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
+++ b/helix-rest/src/main/java/org/apache/helix/rest/server/resources/helix/ClusterAccessor.java
@@ -338,6 +338,14 @@ public class ClusterAccessor extends AbstractHelixResource {
           // NOP
         }
 
+        // Filter out isAutomation and reason keys from customFieldsMap as they are already handled as
+        // TriggeringEntity and REASON
+        if (customFieldsMap != null) {
+          customFieldsMap.entrySet().removeIf(entry ->
+              "isAutomation".equalsIgnoreCase(entry.getKey()) ||
+                  "reason".equalsIgnoreCase(entry.getKey()));
+        }
+
         // Choose the appropriate method based on the triggering entity
         if (isAutomationTriggered) {
           helixAdmin


### PR DESCRIPTION
### Issues

- [ ] My PR addresses the following Helix issues and references them in the PR description:

(#200 - Link your issue number here: You can write "Fixes #XXX". Please use the proper keyword so that the issue gets closed automatically. See https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Any of the following keywords can be used: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved)
This PR closes #3041 , adds support for Maintenance mode Stacking.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

(Write a concise description including what, why, how)
The current implementation of maintenance mode for clusters supports only a single reason at a time, tracked using the simpleFields.REASON key. This restricts the functionality to a single actor and reason, which limits flexibility and coordination.

This proposal introduces a new design that allows multiple actors to independently place a cluster into maintenance mode for different reasons. We will extend the maintenance mode design to support multiple actors, each capable of independently adding or removing their own maintenance reason. The cluster will remain in maintenance mode as long as at least one active reason exists. Each reason will be associated with metadata such as the actor, reason, and timestamp. For backwards compatibility, the existing simpleFields.REASON will be retained and updated to reflect the most recent active reason. If a reason is removed, it will be replaced with the next most recent one. While legacy clients that remove the entire znode cannot be completely prevented, we will handle such cases gracefully and recommend migrating to an updated API that enables proper multi-actor maintenance handling.

### Tests

- [ ] The following tests are written for this issue:
testAutomationMaintenanceMode, testRemoveMaintenanceReasonNoDuplicates, testLegacyClientCompatibility, testMaintenanceHistoryAfterOperationFlag, testMultiActorMaintenanceModeExitSequence, testMultiActorMaintenanceModeReconciliation, testMultiActorMaintenanceModeOldClientExit, testMultiActorMaintenanceModeOldClientOverride, testMultiActorMaintenanceModeInvalidExit

(List the names of added unit/integration tests)

- The following is the result of the "mvn test" command on the appropriate module:

(If CI test fails due to known issue, please specify the issue and test PR locally. Then copy & paste the result of "mvn test" to here.)

### Changes that Break Backward Compatibility (Optional)

- My PR contains changes that break backward compatibility or previous assumptions for certain methods or API. They include:

(Consider including all behavior changes for public methods or API. Also include these changes in merge description so that other developers are aware of these changes. This allows them to make relevant code changes in feature branches accounting for the new method/API behavior.)

### Documentation (Optional)

- In case of new functionality, my PR adds documentation in the following wiki page:

(Link the GitHub wiki you added)

### Commits

- My commits all reference appropriate Apache Helix GitHub issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Code Quality

- My diff has been formatted using helix-style.xml 
(helix-style-intellij.xml if IntelliJ IDE is used)
